### PR TITLE
fix: Jekyll Liquid処理による{{date}}等テンプレート変数の消失を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+---
+render_with_liquid: false
+---
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+render_with_liquid: false
+---
+
 # Google Calendar Template
 
 Googleカレンダーで予定を作成する際に、事前に保存したテンプレートを適用できるChrome拡張機能。

--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -1,3 +1,7 @@
+---
+render_with_liquid: false
+---
+
 # インストール・使用方法ガイド
 
 Google Calendar Template 拡張機能のインストールと使用方法を説明します。


### PR DESCRIPTION
## 問題

GitHub Pages（Jekyll）は `{{date}}` などの `{{...}}` 記法を Liquid テンプレート変数として処理します。未定義の変数は空文字に置換されるため、README や INSTALL_GUIDE 上でテンプレート変数の説明が消えて表示されていました。

バッククォートで囲んだ `` `{{date}}` `` も、Markdown 変換の前に Liquid が処理するため同様に消えてしまいます。

## 修正内容

以下のファイルの先頭に `render_with_liquid: false` front matter を追加：

- `README.md`
- `CHANGELOG.md`
- `docs/INSTALL_GUIDE.md`

これにより Jekyll が Liquid 処理をスキップし、`{{date}}` 等がそのまま表示されます。  
なお、GitHub.com の通常のファイルビュー表示には影響しません。

## 確認事項

- [ ] GitHub Pages で `{{date}}`、`{{date_jp}}`、`{{date_calendar}}` 等が正しく表示されること

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReZyXLfg5BtvZqdcvTxQjs)_