### PR TITLE
fix: README.md に permalink: / を追加してルートの 404 を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-render_with_liquid: false
+permalink: /
 ---
 
 # Google Calendar Template


### PR DESCRIPTION
## 問題

`https://maru0014.github.io/google-calendar-template/` にアクセスすると 404 が返っていた。

GitHub Pages のエラーメッセージ: "For root URLs you must provide an index.html file."

## 原因

`jekyll-readme-index` プラグインが README.md をルートの index として認識できていなかった。

## 修正

README.md の front matter に `permalink: /` を追加。Jekyll が明示的に README.md を `/` に配置し、`index.html` を生成するようになる。

あわせて、効果のなかった `render_with_liquid: false` を削除（変数エスケープは `{% raw %}` タグで対応済み）。

https://claude.ai/code/session_01ReZyXLfg5BtvZqdcvTxQjs

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReZyXLfg5BtvZqdcvTxQjs)_